### PR TITLE
[DL] make ground truth pose data loader

### DIFF
--- a/mg/run.py
+++ b/mg/run.py
@@ -14,8 +14,8 @@ def PlayDataset(dataset, img_pair_q):
     cnt = dataset.get_data_len()
     awake = True
     for index in range(cnt):
-        rgb, gray, d = dataset.ReturnData(index + begin_index)
-        img_pair_q.put([awake, [rgb, gray, d]])
+        rgb, gray, d, pose = dataset.ReturnData(index + begin_index)
+        img_pair_q.put([awake, [rgb, gray, d, pose]])
 
 def TrackingTorch(dataset, parameters, img_pair_q, tracking_result_q):
     tracker = TrackerTorch(dataset, parameters)


### PR DESCRIPTION
- 'pose' in 'run.py' is relative poses list and each component is np.array
- for replica_dataset.py and scannet_dataset.py doesn't need initialize, but for tum_dataset.py need to initialize once more to get 'associated_gt.txt'